### PR TITLE
fazendo chamada do back usando Alamofire

### DIFF
--- a/ChefDelivery.xcodeproj/project.pbxproj
+++ b/ChefDelivery.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		9ABF1FA92DB6B3A0008522A4 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 9ABF1FA82DB6B3A0008522A4 /* Alamofire */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		9A93F97B2DB2ED8A001C61A8 /* ChefDelivery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChefDelivery.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -23,6 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ABF1FA92DB6B3A0008522A4 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +70,7 @@
 			);
 			name = ChefDelivery;
 			packageProductDependencies = (
+				9ABF1FA82DB6B3A0008522A4 /* Alamofire */,
 			);
 			productName = ChefDelivery;
 			productReference = 9A93F97B2DB2ED8A001C61A8 /* ChefDelivery.app */;
@@ -94,6 +100,9 @@
 			);
 			mainGroup = 9A93F9722DB2ED8A001C61A8;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9ABF1FA72DB6B3A0008522A4 /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9A93F97C2DB2ED8A001C61A8 /* Products */;
 			projectDirPath = "";
@@ -324,6 +333,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9ABF1FA72DB6B3A0008522A4 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = exactVersion;
+				version = 5.10.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9ABF1FA82DB6B3A0008522A4 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9ABF1FA72DB6B3A0008522A4 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9A93F9732DB2ED8A001C61A8 /* Project object */;
 }

--- a/ChefDelivery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ChefDelivery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e8f130fe30ac6cdc940ef06ee1e8535e9f46ffee6aeead1722b9525562f6ce08",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ChefDelivery/App/ContentView.swift
+++ b/ChefDelivery/App/ContentView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct ContentView: View {
     
-    private var service = HomeService()
+//    private var service: HomeService = HomeServiceDefaultImpl() // URLSession
+    private var service: HomeService = HomeServiceAlamofireImpl() //Alamofire
     @State private var stores: [StoreType] = []
     @State private var isLoading: Bool = true
     


### PR DESCRIPTION
This pull request introduces the integration of Alamofire into the `ChefDelivery` project for networking purposes, replacing the default `URLSession` implementation. It includes updates to the Xcode project configuration, networking code, and dependency management files.

### Alamofire Integration:

* **Xcode Project Configuration**:
  - Added Alamofire as a Swift Package dependency in `ChefDelivery.xcodeproj/project.pbxproj`. This includes references to the package repository, version (`5.10.2`), and product dependency. [[1]](diffhunk://#diff-e21c7aeaa348b276eae35f1b20214f639833c1a8a47d123271abfa38fb6a117bR9-R12) [[2]](diffhunk://#diff-e21c7aeaa348b276eae35f1b20214f639833c1a8a47d123271abfa38fb6a117bR30) [[3]](diffhunk://#diff-e21c7aeaa348b276eae35f1b20214f639833c1a8a47d123271abfa38fb6a117bR73) [[4]](diffhunk://#diff-e21c7aeaa348b276eae35f1b20214f639833c1a8a47d123271abfa38fb6a117bR103-R105) [[5]](diffhunk://#diff-e21c7aeaa348b276eae35f1b20214f639833c1a8a47d123271abfa38fb6a117bR336-R354)
  - Updated the `Package.resolved` file to include the Alamofire dependency with its specific version and revision.

* **Networking Code Updates**:
  - Refactored the `HomeService` structure into a protocol (`HomeService`) with two implementations:
    - `HomeServiceDefaultImpl`: The existing `URLSession`-based implementation.
    - [`HomeServiceAlamofireImpl`](diffhunk://#diff-5650e52718185b984f41d8a193102e4c748365c55664dbb454f8118b20ddb495R9-R21): A new implementation using Alamofire for making network requests. [[1]](diffhunk://#diff-5650e52718185b984f41d8a193102e4c748365c55664dbb454f8118b20ddb495R9-R21) [[2]](diffhunk://#diff-5650e52718185b984f41d8a193102e4c748365c55664dbb454f8118b20ddb495R45-R63)
  - Updated `ContentView.swift` to use `HomeServiceAlamofireImpl` as the default networking service.

These changes improve the project's networking capabilities by leveraging Alamofire's advanced features and simplify dependency management through Swift Package Manager.